### PR TITLE
Fixed executable name of the command-line interpreter on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,15 @@ module.exports = function start(cmd, opts, cb) {
 
     util.log(prefix + '$ ' + util.colors.magenta(cmd));
 
-    return spawn('sh', ['-c', cmd], opts)
+    var shell = /^win/.test(process.platform) ? {
+        cmd: 'cmd.exe',
+        option: '/C'
+    } : {
+        cmd: 'sh',
+        option: '-c'
+    };
+
+    return spawn(shell.cmd, [shell.option, cmd], opts)
         .on('close', function (code) {
             if (code === 0) { return cb(); }
 


### PR DESCRIPTION
sh shell is not available on Windows by default
![screen shot 2015-03-03 at 1 22 21 pm](https://cloud.githubusercontent.com/assets/47926/6460587/6c5e8d74-c1a9-11e4-944e-658dfced58c0.png)
